### PR TITLE
adjust optional filters width

### DIFF
--- a/spring-2024.html
+++ b/spring-2024.html
@@ -24,7 +24,7 @@ label {
 
 .optional_filters_div {
   margin: auto;
-  width: 40%;
+  min-width: 375px;
   border: 3px solid gray;
   padding: 5px;
   display: none;


### PR DESCRIPTION
Simple change to get the optional headers to display properly on mobile screen sizes.